### PR TITLE
:recycle: Refactor codebase

### DIFF
--- a/src/browser/client.rs
+++ b/src/browser/client.rs
@@ -1,0 +1,41 @@
+use cef::{Client, rc::*, *};
+
+pub struct PClient(*mut RcImpl<cef_dll_sys::_cef_client_t, Self>);
+
+impl PClient {
+    pub fn new() -> Client {
+        Client::new(Self(std::ptr::null_mut()))
+    }
+}
+
+impl WrapClient for PClient {
+    fn wrap_rc(&mut self, object: *mut RcImpl<cef_dll_sys::_cef_client_t, Self>) {
+        self.0 = object;
+    }
+}
+
+impl Clone for PClient{
+    fn clone(&self) -> Self {
+        unsafe {
+            let rc_impl = &mut *self.0;
+            rc_impl.interface.add_ref();
+        }
+
+        Self(self.0)
+    }
+}
+
+impl Rc for PClient {
+    fn as_base(&self) -> &cef_dll_sys::cef_base_ref_counted_t {
+        unsafe {
+            let base = &*self.0;
+            std::mem::transmute(&base.cef_object)
+        }
+    }
+}
+
+impl ImplClient for PClient{
+    fn get_raw(&self) -> *mut cef_dll_sys::_cef_client_t {
+        self.0.cast()
+    }
+}

--- a/src/browser/keybinds.rs
+++ b/src/browser/keybinds.rs
@@ -1,0 +1,84 @@
+use std::collections::HashMap;
+
+#[derive(Debug, Clone)]
+pub enum VimAction {
+    ScrollDown,
+    ScrollDownPage,
+    ScrollUp,
+    ScrollUpPage,
+    ScrollLeft,
+    ScrollRight,
+    GoToTop,
+    GoToBottom,
+    SearchMode,
+    YankUrl,
+    EnterInsertMode,
+    LeaveInsertMode,
+    GoToPrevious,
+    GoToNext,
+}
+
+pub struct KeybindingManager {
+    sequence: String,
+    bindings: HashMap<String, VimAction>,
+    in_insert_mode: bool,
+}
+
+impl KeybindingManager {
+    pub fn new() -> Self {
+        let mut bindings = HashMap::new();
+
+        // Basic normal mode keys
+        bindings.insert("j".into(), VimAction::ScrollDown);
+        bindings.insert("k".into(), VimAction::ScrollUp);
+        bindings.insert("h".into(), VimAction::ScrollLeft);
+        bindings.insert("l".into(), VimAction::ScrollRight);
+        bindings.insert("gg".into(), VimAction::GoToTop);
+        bindings.insert("G".into(), VimAction::GoToBottom);
+        bindings.insert("/".into(), VimAction::SearchMode);
+        bindings.insert("i".into(), VimAction::EnterInsertMode);
+        bindings.insert("yy".into(), VimAction::YankUrl);
+        bindings.insert("<Esc>".into(), VimAction::LeaveInsertMode); // Handle with care
+
+        Self {
+            sequence: String::new(),
+            bindings,
+            in_insert_mode: false,
+        }
+    }
+
+    pub fn push_key(&mut self, key: &str) -> Option<VimAction> {
+        if self.in_insert_mode {
+            if key == "<Esc>" {
+                self.in_insert_mode = false;
+                return Some(VimAction::LeaveInsertMode);
+            }
+            return None;
+        }
+
+        self.sequence.push_str(key);
+
+        if let Some(action) = self.bindings.get(&self.sequence) {
+            if let VimAction::EnterInsertMode = action {
+                self.in_insert_mode = true;
+            }
+            self.sequence.clear();
+            return Some(action.clone());
+        }
+
+        if !self
+            .bindings
+            .keys()
+            .any(|k| k.starts_with(&self.sequence))
+        {
+            self.sequence.clear();
+        }
+
+        None
+    }
+
+    pub fn is_insert_mode(&self) -> bool {
+        self.in_insert_mode
+    }
+}
+

--- a/src/browser/mod.rs
+++ b/src/browser/mod.rs
@@ -1,0 +1,4 @@
+pub mod keybinds;
+pub mod client;
+pub mod view;
+pub mod window;

--- a/src/browser/view.rs
+++ b/src/browser/view.rs
@@ -1,0 +1,95 @@
+use cef::{rc::*, *};
+
+pub struct PWindowDelegate {
+    base: *mut RcImpl<cef_dll_sys::_cef_window_delegate_t, Self>,
+    pub browser_view: BrowserView,
+}
+
+impl PWindowDelegate {
+    pub fn new(browser_view: BrowserView) -> WindowDelegate {
+        WindowDelegate::new(Self {
+            base: std::ptr::null_mut(),
+            browser_view,
+        })
+    }
+}
+
+impl WrapWindowDelegate for PWindowDelegate {
+    fn wrap_rc(&mut self, object: *mut RcImpl<cef_dll_sys::_cef_window_delegate_t, Self>) {
+        self.base = object;
+    }
+}
+
+impl Clone for PWindowDelegate {
+    fn clone(&self) -> Self {
+        unsafe {
+            let rc_impl = &mut *self.base;
+            rc_impl.interface.add_ref();
+        }
+
+        Self {
+            base: self.base,
+            browser_view: self.browser_view.clone(),
+        }
+    }
+}
+
+impl Rc for PWindowDelegate {
+    fn as_base(&self) -> &cef_dll_sys::cef_base_ref_counted_t {
+        unsafe {
+            let base = &*self.base;
+            std::mem::transmute(&base.cef_object)
+        }
+    }
+}
+
+impl ImplViewDelegate for PWindowDelegate {
+    fn on_child_view_changed(
+        &self,
+        _view: Option<&mut View>,
+        _added: ::std::os::raw::c_int,
+        _child: Option<&mut View>,
+    ) {
+        // view.as_panel().map(|x| x.as_window().map(|w| w.close()));
+    }
+
+    fn get_raw(&self) -> *mut cef_dll_sys::_cef_view_delegate_t {
+        self.base.cast()
+    }
+}
+
+impl ImplPanelDelegate for PWindowDelegate {}
+
+impl ImplWindowDelegate for PWindowDelegate {
+    fn on_window_created(&self, window: Option<&mut Window>) {
+        if let Some(window) = window {
+            let view = self.browser_view.clone();
+            window.add_child_view(Some(&mut (&view).into()));
+            window.show();
+        }
+    }
+
+    fn on_window_destroyed(&self, _window: Option<&mut Window>) {
+        quit_message_loop();
+    }
+
+    fn with_standard_window_buttons(&self, _window: Option<&mut Window>) -> ::std::os::raw::c_int {
+        1
+    }
+
+    fn can_resize(&self, _window: Option<&mut Window>) -> ::std::os::raw::c_int {
+        1
+    }
+
+    fn can_maximize(&self, _window: Option<&mut Window>) -> ::std::os::raw::c_int {
+        1
+    }
+
+    fn can_minimize(&self, _window: Option<&mut Window>) -> ::std::os::raw::c_int {
+        1
+    }
+
+    fn can_close(&self, _window: Option<&mut Window>) -> ::std::os::raw::c_int {
+        1
+    }
+}

--- a/src/browser/window.rs
+++ b/src/browser/window.rs
@@ -1,0 +1,7 @@
+use crate::browser::view::PWindowDelegate;
+use cef::{window_create_top_level, BrowserView, Window};
+
+pub fn create_main_window(browser_view: BrowserView) -> Option<Window> {
+    let mut delegate = PWindowDelegate::new(browser_view);
+    window_create_top_level(Some(&mut delegate))
+}

--- a/src/handlers/app.rs
+++ b/src/handlers/app.rs
@@ -1,0 +1,55 @@
+use cef::{rc::*, *};
+use crate::handlers::browser_process::PBrowserProcessHandler;
+use std::sync::{Arc, Mutex};
+
+pub struct PApp {
+    pub object: *mut RcImpl<cef_dll_sys::_cef_app_t, Self>,
+    pub window: Arc<Mutex<Option<Window>>>,
+}
+
+impl PApp {
+    pub fn new(window: Arc<Mutex<Option<Window>>>) -> App {
+        App::new(Self {
+            object: std::ptr::null_mut(),
+            window,
+        })
+    }
+}
+
+impl WrapApp for PApp {
+    fn wrap_rc(&mut self, object: *mut RcImpl<cef_dll_sys::_cef_app_t, Self>) {
+        self.object = object;
+    }
+}
+
+impl Clone for PApp {
+    fn clone(&self) -> Self {
+        let object = unsafe {
+            let rc_impl = &mut *self.object;
+            rc_impl.interface.add_ref();
+            self.object
+        };
+        let window = self.window.clone();
+
+        Self { object, window }
+    }
+}
+
+impl Rc for PApp {
+    fn as_base(&self) -> &cef_dll_sys::cef_base_ref_counted_t {
+        unsafe {
+            let base = &*self.object;
+            std::mem::transmute(&base.cef_object)
+        }
+    }
+}
+
+impl ImplApp for PApp {
+    fn get_raw(&self) -> *mut cef_dll_sys::_cef_app_t {
+        self.object.cast()
+    }
+
+    fn browser_process_handler(&self) -> Option<BrowserProcessHandler> {
+        Some(PBrowserProcessHandler::new(self.window.clone()))
+    }
+}

--- a/src/handlers/browser_process.rs
+++ b/src/handlers/browser_process.rs
@@ -1,0 +1,75 @@
+use crate::browser::window::create_main_window;
+use crate::browser::client::PClient;
+use crate::Window;
+use cef::{rc::*, *};
+use std::sync::{Arc, Mutex};
+
+pub struct PBrowserProcessHandler {
+    pub object: *mut RcImpl<cef_dll_sys::cef_browser_process_handler_t, Self>,
+    pub window: Arc<Mutex<Option<Window>>>,
+}
+
+impl PBrowserProcessHandler {
+    pub fn new(window: Arc<Mutex<Option<Window>>>) -> BrowserProcessHandler {
+        BrowserProcessHandler::new(Self {
+            object: std::ptr::null_mut(),
+            window,
+        })
+    }
+}
+
+impl Rc for PBrowserProcessHandler {
+    fn as_base(&self) -> &cef_dll_sys::cef_base_ref_counted_t {
+        unsafe {
+            let base = &*self.object;
+            std::mem::transmute(&base.cef_object)
+        }
+    }
+}
+
+impl WrapBrowserProcessHandler for PBrowserProcessHandler {
+    fn wrap_rc(&mut self, object: *mut RcImpl<cef_dll_sys::_cef_browser_process_handler_t, Self>) {
+        self.object = object;
+    }
+}
+
+impl Clone for PBrowserProcessHandler {
+    fn clone(&self) -> Self {
+        let object = unsafe {
+            let rc_impl = &mut *self.object;
+            rc_impl.interface.add_ref();
+            rc_impl
+        };
+
+        let window = self.window.clone();
+
+        Self { object, window }
+    }
+}
+
+impl ImplBrowserProcessHandler for PBrowserProcessHandler {
+    fn get_raw(&self) -> *mut cef_dll_sys::_cef_browser_process_handler_t {
+        self.object.cast()
+    }
+
+    // The real lifespan of cef starts from `on_context_initialized`, so all the cef objects should be manipulated after that.
+    fn on_context_initialized(&self) {
+        println!("cef context intiialized");
+        let mut client = PClient::new();
+        let url = CefString::from("https://www.google.com");
+
+        let browser_view = browser_view_create(
+            Some(&mut client),
+            Some(&url),
+            Some(&Default::default()),
+            Option::<&mut DictionaryValue>::None,
+            Option::<&mut RequestContext>::None,
+            Option::<&mut BrowserViewDelegate>::None,
+        )
+        .expect("Failed to create browser view");
+
+        if let Ok(mut window) = self.window.lock() {
+            *window = create_main_window(browser_view);
+        }
+    }
+}

--- a/src/handlers/mod.rs
+++ b/src/handlers/mod.rs
@@ -1,0 +1,2 @@
+pub mod app;
+pub mod browser_process;

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,286 +1,21 @@
-use cef::{args::Args, rc::*, sandbox_info::SandboxInfo, *};
+mod browser;
+mod handlers;
+mod sandbox;
+
+use cef::rc::Rc;
+use cef::{args::Args, *};
+use handlers::app::PApp;
 use std::sync::{Arc, Mutex};
 
-struct DemoApp {
-    object: *mut RcImpl<cef_dll_sys::_cef_app_t, Self>,
-    window: Arc<Mutex<Option<Window>>>,
-}
-
-impl DemoApp {
-    fn new(window: Arc<Mutex<Option<Window>>>) -> App {
-        App::new(Self {
-            object: std::ptr::null_mut(),
-            window,
-        })
-    }
-}
-
-impl WrapApp for DemoApp {
-    fn wrap_rc(&mut self, object: *mut RcImpl<cef_dll_sys::_cef_app_t, Self>) {
-        self.object = object;
-    }
-}
-
-impl Clone for DemoApp {
-    fn clone(&self) -> Self {
-        let object = unsafe {
-            let rc_impl = &mut *self.object;
-            rc_impl.interface.add_ref();
-            self.object
-        };
-        let window = self.window.clone();
-
-        Self { object, window }
-    }
-}
-
-impl Rc for DemoApp {
-    fn as_base(&self) -> &cef_dll_sys::cef_base_ref_counted_t {
-        unsafe {
-            let base = &*self.object;
-            std::mem::transmute(&base.cef_object)
-        }
-    }
-}
-
-impl ImplApp for DemoApp {
-    fn get_raw(&self) -> *mut cef_dll_sys::_cef_app_t {
-        self.object.cast()
-    }
-
-    fn browser_process_handler(&self) -> Option<BrowserProcessHandler> {
-        Some(DemoBrowserProcessHandler::new(self.window.clone()))
-    }
-}
-
-struct DemoBrowserProcessHandler {
-    object: *mut RcImpl<cef_dll_sys::cef_browser_process_handler_t, Self>,
-    window: Arc<Mutex<Option<Window>>>,
-}
-
-impl DemoBrowserProcessHandler {
-    fn new(window: Arc<Mutex<Option<Window>>>) -> BrowserProcessHandler {
-        BrowserProcessHandler::new(Self {
-            object: std::ptr::null_mut(),
-            window,
-        })
-    }
-}
-
-impl Rc for DemoBrowserProcessHandler {
-    fn as_base(&self) -> &cef_dll_sys::cef_base_ref_counted_t {
-        unsafe {
-            let base = &*self.object;
-            std::mem::transmute(&base.cef_object)
-        }
-    }
-}
-
-impl WrapBrowserProcessHandler for DemoBrowserProcessHandler {
-    fn wrap_rc(&mut self, object: *mut RcImpl<cef_dll_sys::_cef_browser_process_handler_t, Self>) {
-        self.object = object;
-    }
-}
-
-impl Clone for DemoBrowserProcessHandler {
-    fn clone(&self) -> Self {
-        let object = unsafe {
-            let rc_impl = &mut *self.object;
-            rc_impl.interface.add_ref();
-            rc_impl
-        };
-
-        let window = self.window.clone();
-
-        Self { object, window }
-    }
-}
-
-impl ImplBrowserProcessHandler for DemoBrowserProcessHandler {
-    fn get_raw(&self) -> *mut cef_dll_sys::_cef_browser_process_handler_t {
-        self.object.cast()
-    }
-
-    // The real lifespan of cef starts from `on_context_initialized`, so all the cef objects should be manipulated after that.
-    fn on_context_initialized(&self) {
-        println!("cef context intiialized");
-        let mut client = DemoClient::new();
-        let url = CefString::from("https://www.google.com");
-
-        let browser_view = browser_view_create(
-            Some(&mut client),
-            Some(&url),
-            Some(&Default::default()),
-            Option::<&mut DictionaryValue>::None,
-            Option::<&mut RequestContext>::None,
-            Option::<&mut BrowserViewDelegate>::None,
-        )
-        .expect("Failed to create browser view");
-
-        let mut delegate = DemoWindowDelegate::new(browser_view);
-        if let Ok(mut window) = self.window.lock() {
-            *window = Some(
-                window_create_top_level(Some(&mut delegate)).expect("Failed to create window"),
-            );
-        }
-    }
-}
-
-struct DemoClient(*mut RcImpl<cef_dll_sys::_cef_client_t, Self>);
-
-impl DemoClient {
-    fn new() -> Client {
-        Client::new(Self(std::ptr::null_mut()))
-    }
-}
-
-impl WrapClient for DemoClient {
-    fn wrap_rc(&mut self, object: *mut RcImpl<cef_dll_sys::_cef_client_t, Self>) {
-        self.0 = object;
-    }
-}
-
-impl Clone for DemoClient {
-    fn clone(&self) -> Self {
-        unsafe {
-            let rc_impl = &mut *self.0;
-            rc_impl.interface.add_ref();
-        }
-
-        Self(self.0)
-    }
-}
-
-impl Rc for DemoClient {
-    fn as_base(&self) -> &cef_dll_sys::cef_base_ref_counted_t {
-        unsafe {
-            let base = &*self.0;
-            std::mem::transmute(&base.cef_object)
-        }
-    }
-}
-
-impl ImplClient for DemoClient {
-    fn get_raw(&self) -> *mut cef_dll_sys::_cef_client_t {
-        self.0.cast()
-    }
-}
-
-struct DemoWindowDelegate {
-    base: *mut RcImpl<cef_dll_sys::_cef_window_delegate_t, Self>,
-    browser_view: BrowserView,
-}
-
-impl DemoWindowDelegate {
-    fn new(browser_view: BrowserView) -> WindowDelegate {
-        WindowDelegate::new(Self {
-            base: std::ptr::null_mut(),
-            browser_view,
-        })
-    }
-}
-
-impl WrapWindowDelegate for DemoWindowDelegate {
-    fn wrap_rc(&mut self, object: *mut RcImpl<cef_dll_sys::_cef_window_delegate_t, Self>) {
-        self.base = object;
-    }
-}
-
-impl Clone for DemoWindowDelegate {
-    fn clone(&self) -> Self {
-        unsafe {
-            let rc_impl = &mut *self.base;
-            rc_impl.interface.add_ref();
-        }
-
-        Self {
-            base: self.base,
-            browser_view: self.browser_view.clone(),
-        }
-    }
-}
-
-impl Rc for DemoWindowDelegate {
-    fn as_base(&self) -> &cef_dll_sys::cef_base_ref_counted_t {
-        unsafe {
-            let base = &*self.base;
-            std::mem::transmute(&base.cef_object)
-        }
-    }
-}
-
-impl ImplViewDelegate for DemoWindowDelegate {
-    fn on_child_view_changed(
-        &self,
-        _view: Option<&mut View>,
-        _added: ::std::os::raw::c_int,
-        _child: Option<&mut View>,
-    ) {
-        // view.as_panel().map(|x| x.as_window().map(|w| w.close()));
-    }
-
-    fn get_raw(&self) -> *mut cef_dll_sys::_cef_view_delegate_t {
-        self.base.cast()
-    }
-}
-
-impl ImplPanelDelegate for DemoWindowDelegate {}
-
-impl ImplWindowDelegate for DemoWindowDelegate {
-    fn on_window_created(&self, window: Option<&mut Window>) {
-        if let Some(window) = window {
-            let view = self.browser_view.clone();
-            window.add_child_view(Some(&mut (&view).into()));
-            window.show();
-        }
-    }
-
-    fn on_window_destroyed(&self, _window: Option<&mut Window>) {
-        quit_message_loop();
-    }
-
-    fn with_standard_window_buttons(&self, _window: Option<&mut Window>) -> ::std::os::raw::c_int {
-        1
-    }
-
-    fn can_resize(&self, _window: Option<&mut Window>) -> ::std::os::raw::c_int {
-        1
-    }
-
-    fn can_maximize(&self, _window: Option<&mut Window>) -> ::std::os::raw::c_int {
-        1
-    }
-
-    fn can_minimize(&self, _window: Option<&mut Window>) -> ::std::os::raw::c_int {
-        1
-    }
-
-    fn can_close(&self, _window: Option<&mut Window>) -> ::std::os::raw::c_int {
-        1
-    }
-}
-
-// FIXME: Rewrite this demo based on cef/tests/cefsimple
 fn main() {
-    #[cfg(target_os = "macos")]
-    let _loader = {
-        let loader = library_loader::LibraryLoader::new(&std::env::current_exe().unwrap(), false);
-        assert!(loader.load());
-        loader
-    };
-
     let _ = api_hash(sys::CEF_API_VERSION_LAST, 0);
-
     let args = Args::new();
     let cmd = args.as_cmd_line().unwrap();
-
-    let sandbox = SandboxInfo::new();
-
-    let switch = CefString::from("type");
-    let is_browser_process = cmd.has_switch(Some(&switch)) != 1;
+    let sandbox = sandbox::create_sandbox();
+    let is_browser_process = cmd.has_switch(Some(&CefString::from("type"))) != 1;
 
     let window = Arc::new(Mutex::new(None));
-    let mut app = DemoApp::new(window.clone());
+    let mut app = PApp::new(window.clone());
 
     let ret = execute_process(
         Some(args.as_main_args()),
@@ -289,15 +24,12 @@ fn main() {
     );
 
     if is_browser_process {
-        println!("launch browser process");
         assert!(ret == -1, "cannot execute browser process");
     } else {
-        let process_type = CefString::from(&cmd.switch_value(Some(&switch)));
-        println!("launch process {process_type}");
         assert!(ret >= 0, "cannot execute non-browser process");
-        // non-browser process does not initialize cef
         return;
     }
+
     let settings = Settings::default();
     assert_eq!(
         initialize(
@@ -311,7 +43,7 @@ fn main() {
 
     run_message_loop();
 
-    let window = window.lock().expect("Failed to lock window");
+    let window = window.lock().unwrap();
     let window = window.as_ref().expect("Window is None");
     assert!(window.has_one_ref());
 

--- a/src/sandbox.rs
+++ b/src/sandbox.rs
@@ -1,0 +1,5 @@
+use cef::sandbox_info::SandboxInfo;
+
+pub fn create_sandbox() -> SandboxInfo {
+    SandboxInfo::new()
+}


### PR DESCRIPTION
Refactoring the codebase is very necessary to make the overhead of understanding a codebase easier.

closes #13 